### PR TITLE
Adding support to filter by named tags (one or multiple)

### DIFF
--- a/grails-app/services/grails/plugins/crm/contact/CrmContactService.groovy
+++ b/grails-app/services/grails/plugins/crm/contact/CrmContactService.groovy
@@ -246,12 +246,26 @@ class CrmContactService {
     def contactCriteria = { query, count, sort ->
         Set<Long> ids = [] as Set
         if (query.tags) {
-            def tagged = crmTagService.findAllIdByTag(CrmContact, query.tags)
-            if(tagged) {
-                ids.addAll(tagged)
+            def tagged
+            if (!(query.tags instanceof String)) {
+                for (tagNameAndValue in query.tags) {
+                    tagged = crmTagService.findAllIdByTag(CrmContact, *(tagNameAndValue.split(':')))
+                    if (tagged) {
+                        ids.addAll(tagged)
+                    }
+                }
+                if (ids.size() == 0) {
+                    ids = NO_RESULT
+                }
             } else {
-                ids = NO_RESULT
+                tagged = crmTagService.findAllIdByTag(CrmContact, *(query.tags.split(':')))
+                if(tagged) {
+                    ids.addAll(tagged)
+                } else {
+                    ids = NO_RESULT
+                }
             }
+
         }
 
         if(query.related) {

--- a/grails-app/services/grails/plugins/crm/contact/CrmContactService.groovy
+++ b/grails-app/services/grails/plugins/crm/contact/CrmContactService.groovy
@@ -248,10 +248,17 @@ class CrmContactService {
         if (query.tags) {
             def tagged
             if (!(query.tags instanceof String)) {
+                def firstTag = query.tags.first()
+                def remaining = query.tags.clone()
+                remaining -= firstTag
+                tagged = crmTagService.findAllIdByTag(CrmContact, *(firstTag.split(':')))
+                if (tagged) {
+                    ids.addAll(tagged)
+                }
                 for (tagNameAndValue in query.tags) {
                     tagged = crmTagService.findAllIdByTag(CrmContact, *(tagNameAndValue.split(':')))
                     if (tagged) {
-                        ids.addAll(tagged)
+                        ids = ids.intersect(tagged)
                     }
                 }
                 if (ids.size() == 0) {

--- a/test/integration/grails/plugins/crm/contact/CrmContactServiceSpec.groovy
+++ b/test/integration/grails/plugins/crm/contact/CrmContactServiceSpec.groovy
@@ -215,12 +215,12 @@ class CrmContactServiceSpec extends grails.plugin.spock.IntegrationSpec {
         crmContactService.list([tags: "level:mid&senior"], [:]).size() == 0
     }
 
-    def "find contacts by multiple tag names"() {
+    def "find contacts by multiple tag names (and)"() {
         when:
         new CrmTag(name: "level").save(failOnError: true)
         new CrmTag(name: "another tag name").save(failOnError: true)
         new CrmContact(firstName: "Developer", lastName: "One").save(failOnError: true).setTagValue("level", "entry").setTagValue("another tag name", "junior")
-        new CrmContact(firstName: "Developer", lastName: "Two").save(failOnError: true).setTagValue("level", "mid")
+        new CrmContact(firstName: "Developer", lastName: "Two").save(failOnError: true).setTagValue("level", "entry")
         new CrmContact(firstName: "Developer", lastName: "Three").save(failOnError: true).setTagValue("level", "senior")
         new CrmContact(firstName: "Developer", lastName: "Four").save(failOnError: true).setTagValue("level", "junior")
         new CrmContact(firstName: "Developer", lastName: "Five").save(failOnError: true).setTagValue("level", "senior")
@@ -228,6 +228,7 @@ class CrmContactServiceSpec extends grails.plugin.spock.IntegrationSpec {
         then:
         crmContactService.list([tags: ["level:entry", "another tag name:junior"]], [:]).size() == 1
     }
+
 
     def "find contacts by parent"() {
         when:

--- a/test/integration/grails/plugins/crm/contact/CrmContactServiceSpec.groovy
+++ b/test/integration/grails/plugins/crm/contact/CrmContactServiceSpec.groovy
@@ -1,6 +1,7 @@
 package grails.plugins.crm.contact
 
 import spock.lang.Shared
+import grails.plugins.crm.tags.CrmTag
 
 class CrmContactServiceSpec extends grails.plugin.spock.IntegrationSpec {
 
@@ -195,6 +196,37 @@ class CrmContactServiceSpec extends grails.plugin.spock.IntegrationSpec {
         crmContactService.list([tags: "java"], [:]).size() == 4
         crmContactService.list([tags: "java,scala"], [:]).size() == 4
         crmContactService.list([tags: "groovy&grails"], [:]).size() == 3
+    }
+
+
+    def "find contacts by named tag"() {
+        when:
+        new CrmTag(name: "level").save(failOnError: true)
+        new CrmTag(name: "another tag name").save(failOnError: true)
+        new CrmContact(firstName: "Developer", lastName: "One").save(failOnError: true).setTagValue("level", "entry").setTagValue("another tag name", "junior")
+        new CrmContact(firstName: "Developer", lastName: "Two").save(failOnError: true).setTagValue("level", "mid")
+        new CrmContact(firstName: "Developer", lastName: "Three").save(failOnError: true).setTagValue("level", "senior")
+        new CrmContact(firstName: "Developer", lastName: "Four").save(failOnError: true).setTagValue("level", "junior")
+        new CrmContact(firstName: "Developer", lastName: "Five").save(failOnError: true).setTagValue("level", "senior")
+
+        then:
+        crmContactService.list([tags: ["level:entry"]], [:]).size() == 1
+        crmContactService.list([tags: "level:mid,senior,junior"], [:]).size() == 4
+        crmContactService.list([tags: "level:mid&senior"], [:]).size() == 0
+    }
+
+    def "find contacts by multiple tag names"() {
+        when:
+        new CrmTag(name: "level").save(failOnError: true)
+        new CrmTag(name: "another tag name").save(failOnError: true)
+        new CrmContact(firstName: "Developer", lastName: "One").save(failOnError: true).setTagValue("level", "entry").setTagValue("another tag name", "junior")
+        new CrmContact(firstName: "Developer", lastName: "Two").save(failOnError: true).setTagValue("level", "mid")
+        new CrmContact(firstName: "Developer", lastName: "Three").save(failOnError: true).setTagValue("level", "senior")
+        new CrmContact(firstName: "Developer", lastName: "Four").save(failOnError: true).setTagValue("level", "junior")
+        new CrmContact(firstName: "Developer", lastName: "Five").save(failOnError: true).setTagValue("level", "senior")
+
+        then:
+        crmContactService.list([tags: ["level:entry", "another tag name:junior"]], [:]).size() == 1
     }
 
     def "find contacts by parent"() {


### PR DESCRIPTION
These changes add the support to filter by named tags with multiple values (using OR with commas and AND with ampersand).

To filter by multiple named tags there's only support to AND. I'm hoping to add support to multiple named tags for OR, maybe adding a parameter and calling it like:

 crmContactService.list([tags: ["level:entry", "another tag name:junior", newParameterName: "&"]])
 crmContactService.list([tags: ["level:entry", "another tag name:junior", newParameterName: ","]])
